### PR TITLE
fix the type implicit conversion error

### DIFF
--- a/lib/transforms/transform_siamfc.py
+++ b/lib/transforms/transform_siamfc.py
@@ -134,7 +134,7 @@ class TransformSiamFC(object):
         if self.aug_color:
             offset = np.reshape(np.dot(
                 rgb_variance, np.random.randn(3)), (1, 1, 3))
-            out = patch - offset
+            out = Image.fromarray(np.uint8(patch - offset))
         else:
             out = patch
 


### PR DESCRIPTION
the `np.array` and `PIL.Image` get different scales after converted to tensor.